### PR TITLE
Invert condition for proper name check in createController

### DIFF
--- a/common/src/main/java/net/mt1006/mocap/api/v1/MocapAPI.java
+++ b/common/src/main/java/net/mt1006/mocap/api/v1/MocapAPI.java
@@ -14,7 +14,7 @@ public final class MocapAPI
 {
 	public static @Nullable MocapController createController(MinecraftServer server, String name)
 	{
-		if (Files.checkIfProperName(CommandOutput.DUMMY, name))
+		if (!Files.checkIfProperName(CommandOutput.DUMMY, name))
 		{
 			MocapMod.LOGGER.warn("Failed to create MocapController - improper name!");
 			return null;

--- a/common/src/main/java/net/mt1006/mocap/api/v1/controller/playable/MocapPlayable.java
+++ b/common/src/main/java/net/mt1006/mocap/api/v1/controller/playable/MocapPlayable.java
@@ -21,6 +21,10 @@ public interface MocapPlayable
 	@ApiStatus.Internal
 	static @Nullable MocapPlayable get(CommandInfo info, String name)
 	{
+		if (name == null || name.isEmpty())
+		{
+			return null;
+		}	
 		return switch (name.charAt(0))
 		{
 			case '.' -> SceneFile.get(info, name);


### PR DESCRIPTION
A valid name will return null.
Also sending an empty string will throw
```
java.lang.StringIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:55) ~[?:?] {}
	at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:52) ~[?:?] {}
	at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:213) ~[?:?] {}
	at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:210) ~[?:?] {}
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:98) ~[?:?] {}
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106) ~[?:?] {}
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302) ~[?:?] {}
	at java.base/java.lang.String.checkIndex(String.java:4832) ~[?:?] {re:mixin}
	at java.base/java.lang.StringLatin1.charAt(StringLatin1.java:46) ~[?:?] {}
	at java.base/java.lang.String.charAt(String.java:1555) ~[?:?] {re:mixin}
	at TRANSFORMER/mocap@1.4-alpha-10+mc1.21.5/net.mt1006.mocap.api.v1.controller.playable.MocapPlayable.get(MocapPlayable.java:20)
```