### PR TITLE
feat(minecraft): ported to 26.1

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,21 +1,16 @@
 plugins
 {
-	id "fabric-loom" version "${fabric_loom_version}"
+	id 'net.fabricmc.fabric-loom' version "${fabric_loom_version}"
 }
 
 repositories
 {
-	maven { url = "https://maven.parchmentmc.org/" }
 	maven { url = "https://repo.spongepowered.org/repository/maven-public" }
 }
 
 dependencies
 {
 	minecraft "com.mojang:minecraft:${minecraft_version}"
-	mappings loom.layered {
-		officialMojangMappings()
-		parchment("org.parchmentmc.data:parchment-${parchment_minecraft}:${parchment_version}@zip")
-	}
 
 	compileOnly "org.spongepowered:mixin:0.8.5:processor"
 }

--- a/common/src/main/java/net/mt1006/mocap/events/EntityEvent.java
+++ b/common/src/main/java/net/mt1006/mocap/events/EntityEvent.java
@@ -21,7 +21,7 @@ public class EntityEvent
 
 	public static boolean onEntityDrop(LivingEntity entity)
 	{
-		return !PlaybackManager.playbacks.isEmpty() && entity.getTags().contains(PlaybackManager.MOCAP_ENTITY_TAG);
+		return !PlaybackManager.playbacks.isEmpty() && entity.entityTags().contains(PlaybackManager.MOCAP_ENTITY_TAG);
 	}
 
 	public static void onPlayerRespawn(ServerPlayer oldPlayer, ServerPlayer newPlayer)

--- a/common/src/main/java/net/mt1006/mocap/mixin/EntityMixin.java
+++ b/common/src/main/java/net/mt1006/mocap/mixin/EntityMixin.java
@@ -4,6 +4,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.storage.ValueOutput;
 import net.mt1006.mocap.mocap.playing.PlaybackManager;
 import net.mt1006.mocap.mocap.settings.Settings;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -15,12 +16,13 @@ import java.util.Set;
 @Mixin(Entity.class)
 public abstract class EntityMixin
 {
-	@Shadow public abstract Set<String> getTags();
+	@Shadow
+	public abstract Set<String> entityTags();
 
 	@Inject(method = "save", at = @At(value = "HEAD"), cancellable = true)
 	private void atSave(ValueOutput nbt, CallbackInfoReturnable<Boolean> cir)
 	{
-		if (!PlaybackManager.playbacks.isEmpty() && Settings.PREVENT_SAVING_ENTITIES.val && getTags().contains(PlaybackManager.MOCAP_ENTITY_TAG))
+		if (!PlaybackManager.playbacks.isEmpty() && Settings.PREVENT_SAVING_ENTITIES.val && entityTags().contains(PlaybackManager.MOCAP_ENTITY_TAG))
 		{
 			cir.setReturnValue(false);
 			cir.cancel();

--- a/common/src/main/java/net/mt1006/mocap/mocap/playing/modifiers/EntityFilter.java
+++ b/common/src/main/java/net/mt1006/mocap/mocap/playing/modifiers/EntityFilter.java
@@ -193,7 +193,7 @@ public class EntityFilter implements MocapEntityFilter
 
 		@Override protected boolean applies(Entity entity)
 		{
-			return entity.getTags().contains(tag);
+			return entity.entityTags().contains(tag);
 		}
 	}
 

--- a/common/src/main/java/net/mt1006/mocap/mocap/recording/EntityTracker.java
+++ b/common/src/main/java/net/mt1006/mocap/mocap/recording/EntityTracker.java
@@ -54,7 +54,7 @@ public class EntityTracker
 		for (Entity entity : ((LevelFields)ctx.recordedPlayer.level()).callGetEntities().getAll())
 		{
 			if ((limitDistance && ctx.recordedPlayer.distanceToSqr(entity) > maxDistanceSqr) || entity instanceof Player
-					|| (ctx.config.getPreventTrackingPlayedEntities() && entity.getTags().contains(PlaybackManager.MOCAP_ENTITY_TAG)))
+					|| (ctx.config.getPreventTrackingPlayedEntities() && entity.entityTags().contains(PlaybackManager.MOCAP_ENTITY_TAG)))
 			{
 				continue;
 			}

--- a/common/src/main/java/net/mt1006/mocap/utils/FakePlayer.java
+++ b/common/src/main/java/net/mt1006/mocap/utils/FakePlayer.java
@@ -55,7 +55,6 @@ public class FakePlayer extends ServerPlayer
 	}
 
 	@Override public ServerPlayer teleport(@NotNull TeleportTransition dimensionTransition) { return null; }
-	@Override public void displayClientMessage(@NotNull Component chatComponent, boolean actionBar) { }
 	@Override public void awardStat(@NotNull Stat stat, int amount) { }
 
 	@Override public boolean hurtServer(ServerLevel level, DamageSource damageSource, float amount)

--- a/common/src/main/java/net/mt1006/mocap/utils/Utils.java
+++ b/common/src/main/java/net/mt1006/mocap/utils/Utils.java
@@ -28,13 +28,13 @@ public class Utils
 	public static void sendMessage(@Nullable Player player, String component, Object... args)
 	{
 		if (player == null) { return; }
-		player.displayClientMessage(getTranslatableComponent(player, component, args), false);
+		player.sendSystemMessage(getTranslatableComponent(player, component, args));
 	}
 
 	public static void sendComponent(@Nullable Player player, Component component)
 	{
 		if (player == null) { return; }
-		player.displayClientMessage(component, false);
+		player.sendSystemMessage(component);
 	}
 
 	public static String stringFromComponent(String component, Object... args)

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,24 +1,19 @@
 plugins
 {
-	id "fabric-loom" version "${fabric_loom_version}"
+	id 'net.fabricmc.fabric-loom' version "${fabric_loom_version}"
 }
 
 repositories
 {
-	maven { url = "https://maven.parchmentmc.org/" }
 	maven { url = "https://maven.terraformersmc.com/releases/" }
 }
 
 dependencies
 {
 	minecraft "com.mojang:minecraft:${minecraft_version}"
-	mappings loom.layered {
-		officialMojangMappings()
-		parchment("org.parchmentmc.data:parchment-${parchment_minecraft}:${parchment_version}@zip")
-	}
 
-	modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}"
+	implementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
+	implementation "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}"
 }
 
 loom

--- a/fabric/src/main/java/net/mt1006/mocap/fabric/PacketHandler.java
+++ b/fabric/src/main/java/net/mt1006/mocap/fabric/PacketHandler.java
@@ -13,10 +13,10 @@ public class PacketHandler
 {
 	public static void register()
 	{
-		PayloadTypeRegistry.playC2S().register(MocapPacketC2S.TYPE, MocapPacketC2S.CODEC);
+		PayloadTypeRegistry.serverboundPlay().register(MocapPacketC2S.TYPE, MocapPacketC2S.CODEC);
 		ServerPlayNetworking.registerGlobalReceiver(MocapPacketC2S.TYPE, PacketHandler::serverReceiver);
 
-		PayloadTypeRegistry.playS2C().register(MocapPacketS2C.TYPE, MocapPacketS2C.CODEC);
+		PayloadTypeRegistry.clientboundPlay().register(MocapPacketS2C.TYPE, MocapPacketS2C.CODEC);
 		if (!MocapMod.isDedicatedServer)
 		{
 			ClientPlayNetworking.registerGlobalReceiver(MocapPacketS2C.TYPE, PacketHandler::clientReceiver);

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,31 +12,26 @@ issue_tracker=https://github.com/mt1006/mc-mocap-mod/issues
 mod_description=Allows you to record and replay player movements.
 
 # Minecraft and Java
-minecraft_version=1.21.11
-java_version=21
+minecraft_version=26.1
+java_version=25
 
 # Requires
-version_range_fabric=>=1.21.11
-version_range_neoforge=[1.21.11,)
+version_range_fabric=>=26.1
+version_range_neoforge=[26.1,)
 
 # Loaders
 # https://github.com/FabricMC/fabric-loader/releases
 # https://modrinth.com/mod/fabric-api/versions?c=release
 # https://projects.neoforged.net/neoforged/neoforge
-fabric_loader_version=0.18.4
-fabric_api_version=0.140.2+1.21.11
-neoforge_version=21.11.17-beta
-
-# Mappings
-# https://parchmentmc.org/docs/getting-started
-parchment_minecraft=1.21.10
-parchment_version=2025.10.12
+fabric_loader_version=0.18.5
+fabric_api_version=0.144.3+26.1
+neoforge_version=26.1.0.8-beta
 
 # Gradle dependencies
 # https://github.com/FabricMC/fabric-loom/releases
 # https://projects.neoforged.net/neoforged/ModDevGradle
-fabric_loom_version=1.14-SNAPSHOT
-neoforge_moddev_version=2.0.136
+fabric_loom_version=1.15-SNAPSHOT
+neoforge_moddev_version=2.0.141
 
 # Gradle configuration
 org.gradle.jvmargs=-Xmx3G

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -6,11 +6,6 @@ plugins
 neoForge
 {
 	version = neoforge_version
-	parchment
-	{
-		minecraftVersion = parchment_minecraft
-		mappingsVersion = parchment_version
-	}
 
 	runs
 	{


### PR DESCRIPTION
## Gradle
- Removed parchmnent (since 26.1 Minecraft source code is now unobfuscated)
- Updated to latest fabric and neoforge version
- Updated to Java 25 (be sure to use java 25 sdk in your ide to test)

## Code
- `Entity.class (and mixin)` getTags() -> entityTags()
- `Player.class` displayClientMessage() -> sendSystemMessage()
- `FakePlayer.class` removed `displayClientMessage` override since it no longer exist
- Fabric now use `serverboundPlay` and `clientboundPlay` to register packets


and that's pretty much it, i thought it would be a bit more difficult to port lol 