### PR TITLE
fix: create channel for fake player, remove null exception from NeoForge #113

### DIFF
--- a/common/src/main/java/net/mt1006/mocap/utils/FakePlayer.java
+++ b/common/src/main/java/net/mt1006/mocap/utils/FakePlayer.java
@@ -154,6 +154,7 @@ public class FakePlayer extends ServerPlayer
 		public DummyConnection(PacketFlow packetFlow)
 		{
 			super(packetFlow);
+			new EmbeddedChannel(this);
 		}
 	}
 }

--- a/common/src/main/java/net/mt1006/mocap/utils/FakePlayer.java
+++ b/common/src/main/java/net/mt1006/mocap/utils/FakePlayer.java
@@ -2,6 +2,7 @@ package net.mt1006.mocap.utils;
 
 import com.mojang.authlib.GameProfile;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.embedded.EmbeddedChannel;
 import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.PlayerChatMessage;


### PR DESCRIPTION
This a fix proposal for #113. It creates a channel for the fake player, so when neoforge tries to get the channel from the fake player connection, it does not return null and removes the null pointer exception